### PR TITLE
Make homepage title just "Sparrow," not "Sparrow | Home"

### DIFF
--- a/_layouts/base.html
+++ b/_layouts/base.html
@@ -5,7 +5,13 @@
   content="IE=edge">
 </meta>
 
-<title>Sparrow | {{ page.title }}</title>
+{% if page.title %}
+  {% assign title = "Sparrow | " | append: page.title %}
+{% else %}
+  {% assign title = "Sparrow" %}
+{% endif %}
+
+<title>{{ title }}</title>
 
 <meta
   name="description"
@@ -30,7 +36,7 @@
 
 <meta
   property="og:title"
-  content="Sparrow | {{ page.title }}">
+  content="{{ title }}">
 </meta>
 
 <meta
@@ -60,7 +66,7 @@
 
 <meta
   name="twitter:title"
-  content="Sparrow | {{ page.title }}">
+  content="{{ title }}">
 </meta>
 
 <meta

--- a/index.html
+++ b/index.html
@@ -1,6 +1,5 @@
 ---
 layout: base
-title: Home
 description: "We take care of employee leave, so you don't have to."
 ---
 


### PR DESCRIPTION
Make pages without `title` front matter default to "Sparrow" instead of "Sparrow | <page.title>"
and modify home page to have no title and therefore be just "Sparrow"