### PR TITLE
fixed-twitter-og-cards

### DIFF
--- a/_layouts/base.html
+++ b/_layouts/base.html
@@ -50,7 +50,7 @@
 
 <meta
   name="twitter:card"
-  content="summary">
+  content="summary_large_image">
 </meta>
 
 <meta


### PR DESCRIPTION
Fixed Twitter Card code to include a large image/image in the card/link preview