### PR TITLE
Remove references to in person work from career page

### DIFF
--- a/careers.html
+++ b/careers.html
@@ -90,8 +90,9 @@ banner: "../world/spc_party.jpeg"
         <h3>Life</h3>
 
         <p>
-          We encourage each other as we work remotely, <!--dog-watching during team lunches in the park--> and love chocolate, funny memes, and all things matcha.
-
+          <!--To be restored after the team starts working together again-->
+          <!--We enjoy dog-watching during team lunches in the park, and love chocolate, funny memes, and all things matcha.-->
+          We enjoy dog watching, and we love chocolate, funny memes, and all things matcha.
         </p>
       </div>
     </div>
@@ -121,6 +122,7 @@ banner: "../world/spc_party.jpeg"
 
       <li>Flexible hours</li>
 
+      <!--To be restored after the team starts working together again-->
       <!--<li>Free snacks</li>-->
     </ul>
   </div>

--- a/careers.html
+++ b/careers.html
@@ -90,7 +90,7 @@ banner: "../world/spc_party.jpeg"
         <h3>Life</h3>
 
         <p>
-          We enjoy dog-watching during team lunches in the park, and love chocolate, funny memes, and all things matcha
+          We encourage each other as we work remotely, <!--dog-watching during team lunches in the park--> and love chocolate, funny memes, and all things matcha.
 
         </p>
       </div>
@@ -121,7 +121,7 @@ banner: "../world/spc_party.jpeg"
 
       <li>Flexible hours</li>
 
-      <li>Free snacks</li>
+      <!--<li>Free snacks</li>-->
     </ul>
   </div>
 </div>


### PR DESCRIPTION
If merged, the text I hope to have reviewed would read "We encourage each other as we work remotely, and love chocolate, funny memes, and all things matcha."

<img width="964" alt="Screen Shot 2020-04-21 at 4 21 14 PM" src="https://user-images.githubusercontent.com/11018358/79910949-8e883380-83ed-11ea-94a9-cb46657326ef.png">
