### PR TITLE
content: add links to publicly available policies in footer

### DIFF
--- a/_data/nav.yml
+++ b/_data/nav.yml
@@ -9,3 +9,15 @@
 
 - label: "Customer Stories"
   url: "/customer-stories"
+
+- label: "Privacy"
+  url: "/privacy"
+  footer_only: true
+
+- label: "Security"
+  url: "/security"
+  footer_only: true
+
+- label: "Terms"
+  url: "/terms"
+  footer_only: true

--- a/_includes/navbar.html
+++ b/_includes/navbar.html
@@ -1,8 +1,8 @@
 <nav
   class="navbar navbar-expand-lg
-	{% if page.opaque_navbar %} navbar-light
-	{% else %} navbar-dark bg-transparent
-	{% endif %}"
+  {% if page.opaque_navbar %} navbar-light
+  {% else %} navbar-dark bg-transparent
+  {% endif %}"
   role="navigation">
   <div class="container no-override">
     <a
@@ -26,6 +26,8 @@
       class="collapse navbar-collapse justify-content-end">
       <ul class="navbar-nav">
         {% for link in site.data.nav %}
+        {% if link.footer_only %}
+        {% else %}
           <li class="nav-item active">
             <a
               class="nav-link"
@@ -33,6 +35,7 @@
               {{ link.label }}
             </a>
           </li>
+        {% endif %}
         {% endfor %}
       </ul>
     </div>


### PR DESCRIPTION
## Why is this change being made?
SOC2 requires that some of our policies be very accessible.

## Technically, how does it fit into the bigger picture?
We added the `footer_only` option in nav.yaml.

## What are the security implications of this change?
Hopefully none since this is a static site.